### PR TITLE
Add flags to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,38 @@
 #!/bin/bash
+accept_eula=''
+skip_lib_copy=''
+
+print_usage() {
+  printf "Usage: $0 [ -a Accept EULA ] [ -s skip library copy ]"
+}
+
+while getopts 'as' flag; do
+  case "${flag}" in
+    a) accept_eula='y' ;;
+    s) skip_lib_copy='y' ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+read_eula() {
+	if [[ -z $accept_eula ]];
+	then
+		echo "In order to install this package, you have to accept the EULA"
+		echo "Please use PgDown and PgUp to read the EULA, then press q"
+		read -p "Now please press ENTER " -r
+		less EULA
+		read -p "Do you accept this EULA (y/n)? " -r
+		accept_eula=$REPLY		
+	fi
+}
+
 if [ `which lsb_release 2>/dev/null` ] && [ `lsb_release -i | cut -f2` == 'Ubuntu' ]
 then
-	echo "In order to install this package, you have to accept the EULA"
-	echo "Please use PgDown and PgUp to read the EULA, then press q"
-	read -p "Now please press ENTER " -r
-	less EULA
-	read -p "Do you accept this EULA (y/n)? " -r
-	if [[ $REPLY =~ ^[Yy]$ ]]
+	read_eula
+	if [[ $accept_eula =~ ^[Yy]$ ]]
 	then
-		cp libmicrondla.so /usr/local/lib
+		if [[ -z "$skip_lib_copy" ]]; then cp libmicrondla.so /usr/local/lib; fi
 		apt-get update
 		apt-get -y install python3-pip
 		pip3 install --upgrade numpy
@@ -32,12 +56,8 @@ then
 elif [ -f /etc/redhat-release ] && [ `cut -d ' ' -f1 /etc/redhat-release` == 'CentOS' ] && \
 	[ `cut -d ' ' -f4 /etc/redhat-release | cut -d . -f1 -` == '7' ]
 then
-	echo "In order to install this package, you have to accept the EULA"
-	echo "Please use PgDown and PgUp to read the EULA, then press q"
-	read -p "Now please press ENTER " -r
-	less EULA
-	read -p "Do you accept this EULA (y/n)? " -r
-	if [[ $REPLY =~ ^[Yy]$ ]]
+	read_eula
+	if [[ $accept_eula =~ ^[Yy]$ ]]
 	then
 		if [ -f /etc/ld.so.conf.d/local.conf ]; then
 			if ! grep -q /usr/local/bin /etc/ld.so.conf.d/local.conf; then
@@ -46,7 +66,7 @@ then
 		else
 			echo /usr/local/lib >/etc/ld.so.conf.d/local.conf
 		fi
-	 	cp libmicrondla.so /usr/local/lib
+		if [[ -z "$skip_lib_copy" ]]; then cp libmicrondla.so /usr/local/lib; fi
 		yum install unzip
 		if ! [ -x "$(command -v python3)" ]; then
 			echo "Installing Python3 from source"


### PR DESCRIPTION
Added -a to accept EULA and bypass user interaction
Added -s to skip copying the library (not needed for installs from Pico package)


Here is a first pass at giving the install script a silent mode for our docker builds. I figured command flags would be the most flexible so that the default would match old behavior, but flags could change single behaviors. 